### PR TITLE
added Pull access denied Error

### DIFF
--- a/setup/choose-your-setup/deploy-on-cloud.mdx
+++ b/setup/choose-your-setup/deploy-on-cloud.mdx
@@ -365,6 +365,19 @@ sudo ufw allow 3000/tcp # Development (if needed)
 ```
 </Accordion>
 
+<Accordion title="Pull access denied Error">
+
+**Error**
+- Error response from daemon: `pull access denied for <image-name>, repository does not exist or may require 'docker login'`
+
+**Solutions**
+- Clear Docker Build Cache and Rebuild
+- Remove all Docker build cache and images
+- Run the following command to clear all cached layers and build data: `docker builder prune -a -f`
+- This command removes all unused build cache and intermediate images, ensuring a clean environment.
+- Rebuild the application from scratch
+</Accordion>
+
 </AccordionGroup>
 
 </Tab>

--- a/setup/choose-your-setup/local-setup.mdx
+++ b/setup/choose-your-setup/local-setup.mdx
@@ -252,6 +252,19 @@ Open your browser and navigate to:
 - Verify virtualization is enabled in BIOS
 </Accordion>
 
+<Accordion title="Pull access denied Error">
+
+**Error**
+- Error response from daemon: `pull access denied for <image-name>, repository does not exist or may require 'docker login'`
+
+**Solutions**
+- Clear Docker Build Cache and Rebuild
+- Remove all Docker build cache and images
+- Run the following command to clear all cached layers and build data: `docker builder prune -a -f`
+- This command removes all unused build cache and intermediate images, ensuring a clean environment.
+- Rebuild the application from scratch
+</Accordion>
+
 </AccordionGroup>
 
 </Tab>

--- a/setup/choose-your-setup/local-setup.mdx
+++ b/setup/choose-your-setup/local-setup.mdx
@@ -203,6 +203,19 @@ Open your browser and navigate to:
 - Use `docker system prune` to clean up unused containers and images
 </Accordion>
 
+<Accordion title="Pull access denied Error">
+
+**Error**
+- Error response from daemon: `pull access denied for <image-name>, repository does not exist or may require 'docker login'`
+
+**Solutions**
+- Clear Docker Build Cache and Rebuild
+- Remove all Docker build cache and images
+- Run the following command to clear all cached layers and build data: `docker builder prune -a -f`
+- This command removes all unused build cache and intermediate images, ensuring a clean environment.
+- Rebuild the application from scratch
+</Accordion>
+
 </AccordionGroup>
 
 </Tab>

--- a/setup/choose-your-setup/on-prem.mdx
+++ b/setup/choose-your-setup/on-prem.mdx
@@ -231,6 +231,19 @@ docker compose restart
 ```
 </Accordion>
 
+<Accordion title="Pull access denied Error">
+
+**Error**
+- Error response from daemon: `pull access denied for <image-name>, repository does not exist or may require 'docker login'`
+
+**Solutions**
+- Clear Docker Build Cache and Rebuild
+- Remove all Docker build cache and images
+- Run the following command to clear all cached layers and build data: `docker builder prune -a -f`
+- This command removes all unused build cache and intermediate images, ensuring a clean environment.
+- Rebuild the application from scratch
+</Accordion>
+
 </AccordionGroup>
 
 <Note>


### PR DESCRIPTION
### Added Troubleshoot for Pull access denied error for Local Setup
```

**Pull access denied Error**

**Error**
- Error response from daemon: `pull access denied for <image-name>, repository does not exist or may require 'docker login'`

**Solutions**
- Clear Docker Build Cache and Rebuild
- Remove all Docker build cache and images
- Run the following command to clear all cached layers and build data: `docker builder prune -a -f`
- This command removes all unused build cache and intermediate images, ensuring a clean environment.
- Rebuild the application from scratch
```
<img width="488" height="283" alt="image" src="https://github.com/user-attachments/assets/49e0a9dd-7e58-4de8-b43c-2e1257b246ea" />
